### PR TITLE
Update lib/zfsmbd.rb

### DIFF
--- a/lib/zfsmbd.rb
+++ b/lib/zfsmbd.rb
@@ -14,7 +14,7 @@ module ZFsmb
       begin
         @server = TCPServer.open(ipaddr , 445)
         return @server
-      rescue Errno::EADDRINUSE, Errno::EACCESS
+      rescue Errno::EADDRINUSE, Errno::EACCES
         puts "PORT IN USE OR PERMS"
         return false
       end


### PR DESCRIPTION
It's Errno::EACCES not Errno::EACCESS

http://ruby-doc.org/stdlib-1.9.3/libdoc/socket/rdoc/TCPServer.html
